### PR TITLE
Fixed memory leak, added a couple of features

### DIFF
--- a/stlastar.h
+++ b/stlastar.h
@@ -49,9 +49,15 @@ using namespace std;
 // occurs in stl headers
 #pragma warning( disable : 4786 )
 
+template <class T> class AStarState;
+
 // The AStar search class. UserState is the users state space type
 template <class UserState> class AStarSearch
 {
+
+#if (defined(__cplusplus) && __cplusplus > 199711L) || (defined(_MSC_VER) && _MSC_VER >= 1600)
+	static_assert(is_base_of<AStarState<UserState>, UserState>::value, "UserState must be derived from AStarState!");
+#endif
 
 public: // data
 
@@ -776,6 +782,17 @@ private: // data
 	
 	bool m_CancelRequest;
 
+};
+
+template <class T> class AStarState
+{
+public:
+	virtual ~AStarState() {}
+	virtual float GoalDistanceEstimate( T &nodeGoal ) = 0; // Heuristic function which computes the estimated cost to the goal node
+	virtual bool IsGoal( T &nodeGoal ) = 0; // Returns true if this node is the goal node
+	virtual bool GetSuccessors( AStarSearch<T> *astarsearch, T *parent_node ) = 0; // Retrieves all successors to this node and adds them via astarsearch.addSuccessor()
+	virtual float GetCost( T &successor ) = 0; // Computes the cost of travelling from this node to the successor node
+	virtual bool IsSameState( T &rhs ) = 0; // Returns true if this node is the same as the rhs node
 };
 
 #endif


### PR DESCRIPTION
Hi Justin,

I've fixed a memory leak pertaining to the use of placement new with FSA. Turns out the object destructor needs to be explicitly called when using such a method of creating objects in a specific memory space. Turning off FSA reverts to the normal new allocation, which doesn't leak any memory.

Also, I've added a function to the the total cost g of a solution path at the end of a search. I feel it could be useful to expose the information (and it is only a simple extension).

A template interface has been added as well, to facilitate quick reference to the functions AStarSearch requires. I found myself referring back to your sample files often when implementing the functions, and thought it would be good to consolidate that information in the header file.

Thanks for creating this easy-to-use class, and I hope you find my changes useful!
