### PR TITLE
Fix allocated node counter and open/close node linked lists

### DIFF
--- a/cpp/stlastar.h
+++ b/cpp/stlastar.h
@@ -277,6 +277,7 @@ public: // methods
 				m_Successors.clear(); // empty vector of successor nodes to n
 
 				// free up everything else we allocated
+				FreeNode( (n) );
 				FreeAllNodes();
 
 				m_State = SEARCH_STATE_OUT_OF_MEMORY;
@@ -352,42 +353,75 @@ public: // methods
 				(*successor)->h = (*successor)->m_UserState.GoalDistanceEstimate( m_Goal->m_UserState );
 				(*successor)->f = (*successor)->g + (*successor)->h;
 
-				// Remove successor from closed if it was on it
+				// Successor in closed list
+				// 1 - Update old version of this node in closed list
+				// 2 - Move it from closed to open list
+				// 3 - Sort heap again in open list
 
 				if( closedlist_result != m_ClosedList.end() )
 				{
-					// remove it from Closed
-					FreeNode(  (*closedlist_result) ); 
+					// Update closed node with successor node AStar data
+					//*(*closedlist_result) = *(*successor);
+					(*closedlist_result)->parent = (*successor)->parent;
+					(*closedlist_result)->g      = (*successor)->g;
+					(*closedlist_result)->h      = (*successor)->h;
+					(*closedlist_result)->f      = (*successor)->f;
+
+					// Free successor node
+					FreeNode( (*successor) );
+
+					// Push closed node into open list 
+					m_OpenList.push_back( (*closedlist_result) );
+
+					// Remove closed node from closed list
 					m_ClosedList.erase( closedlist_result );
+
+					// Sort back element into heap
+					push_heap( m_OpenList.begin(), m_OpenList.end(), HeapCompare_f() );
 
 					// Fix thanks to ...
 					// Greg Douglas <gregdouglasmail@gmail.com>
 					// who noticed that this code path was incorrect
 					// Here we have found a new state which is already CLOSED
 					// anus
-					
+
 				}
 
-				// Update old version of this node
-				if( openlist_result != m_OpenList.end() )
-				{	   
+				// Successor in open list
+				// 1 - Update old version of this node in open list
+				// 2 - sort heap again in open list
 
-					FreeNode( (*openlist_result) ); 
-			   		m_OpenList.erase( openlist_result );
+				else if( openlist_result != m_OpenList.end() )
+				{
+					// Update open node with successor node AStar data
+					//*(*openlist_result) = *(*successor);
+					(*openlist_result)->parent = (*successor)->parent;
+					(*openlist_result)->g      = (*successor)->g;
+					(*openlist_result)->h      = (*successor)->h;
+					(*openlist_result)->f      = (*successor)->f;
+
+					// Free successor node
+					FreeNode( (*successor) );
 
 					// re-make the heap 
 					// make_heap rather than sort_heap is an essential bug fix
 					// thanks to Mike Ryynanen for pointing this out and then explaining
 					// it in detail. sort_heap called on an invalid heap does not work
 					make_heap( m_OpenList.begin(), m_OpenList.end(), HeapCompare_f() );
-			
 				}
 
-				// heap now unsorted
-				m_OpenList.push_back( (*successor) );
+				// New successor
+				// 1 - Move it from successors to open list
+				// 2 - sort heap again in open list
 
-				// sort back element into heap
-				push_heap( m_OpenList.begin(), m_OpenList.end(), HeapCompare_f() );
+				else
+				{
+					// Push successor node into open list
+					m_OpenList.push_back( (*successor) );
+
+					// Sort back element into heap
+					push_heap( m_OpenList.begin(), m_OpenList.end(), HeapCompare_f() );
+				}
 
 			}
 
@@ -714,6 +748,7 @@ private: // methods
 	{
 
 #if !USE_FSA_MEMORY
+		m_AllocateNodeCount ++;
 		Node *p = new Node;
 		return p;
 #else


### PR DESCRIPTION
Hi, I'm Sergio Sota, from Spain. This is my very first pull request. Sorry for my terrible English :-P I have used your astar algorithm implementation in a bot for an AI contest (check here https://github.com/marcan/lighthouses_aicontest) that will take place this july on Bilbao (Euskal Encounter 26)

The thing is... sometimes somewhere some bot hung (I run many instances of it in parallel with different parameters in order to train) So I begun the bug hunt... it took me almost 2 weeks but finally I think I have found the problem.

1) When there is no more memory (I used the default 1000 node size) the program tries to free all nodes: the open list, the closed list, the goal node... but there is another node that doesn't get freed: the "n" node (the one pulled out from the open list at the beginning and used here and there) I used EnsureMemoryFree method assertion just after that and the program stops (it's not big deal since the astar object gets destroyed once you finish your search)

2) If you select not to use FSA memory allocator... when a node gets freed there is a "m_AllocateNodeCount--" but when a node gets allocated there is no "m_AllocateNodeCount++"

3) This is, I believe, the most important issue: all nodes, once allocated in memory, have references to other nodes... so we can't realloc any of them or the solution chain could be broken. e.g. (A) -> (B) -> (C) if we realloc B to other place it will still point to C, but now A is pointing to the position B occupied. If FSA doesn't use that block then we are lucky, but if it is somehow refilled with other block D... then we have (A) -> (D) -> (?)
In other words... when we have a successor that will replace other old open/close node (because this successor has a better path) we must change the old/close node in place (because other node could be pointing to it) Right now the successor is pulled in as a new node and the old open/closed node is erased... and that could broke the chain.

Well, I have tested the modified version and it is working ok so far! Thanks for you time and for your great project :-)
