### PR TITLE
Undo latest changes

### DIFF
--- a/cpp/findpath.cpp
+++ b/cpp/findpath.cpp
@@ -8,8 +8,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-using namespace std;
-
 #include "stlastar.h" // See header for copyright and usage information
 
 #include <iostream>
@@ -18,6 +16,8 @@ using namespace std;
 
 #define DEBUG_LISTS 0
 #define DEBUG_LIST_LENGTHS_ONLY 0
+
+using namespace std;
 
 // Global data
 

--- a/cpp/min_path_to_Bucharest.cpp
+++ b/cpp/min_path_to_Bucharest.cpp
@@ -17,9 +17,6 @@
 // accurate heuristics. In fact, that is part of the point of this example, in the book you will see Norvig
 // mention that the algorithm does some backtracking because the heuristic is not accurate (yet still admissable).
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-using namespace std;
-
 #include "stlastar.h"
 #include <iostream>
 #include <string>
@@ -28,6 +25,8 @@ using namespace std;
 
 #define DEBUG_LISTS 0
 #define DEBUG_LIST_LENGTHS_ONLY 0
+
+using namespace std;
 
 const int MAX_CITIES = 20;
 

--- a/cpp/stlastar.h
+++ b/cpp/stlastar.h
@@ -37,6 +37,8 @@ given where due.
 #include <vector>
 #include <cfloat>
 
+using namespace std;
+
 // fast fixed size memory allocator, used for fast node memory management
 #include "fsa.h"
 

--- a/cpp/tests.cpp
+++ b/cpp/tests.cpp
@@ -3,9 +3,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
-
-using namespace std;
-
 #include "stlastar.h"
 
 const int MAP_WIDTH = 20;


### PR DESCRIPTION
Close if not applicable,

Last changes that removes the namespace from the headers breaks code that imports  the header files and expect the namespace to be part of the header so is automatically imported