### PR TITLE
Use a hash set for the closed state list

### DIFF
--- a/cpp/8puzzle.cpp
+++ b/cpp/8puzzle.cpp
@@ -78,9 +78,9 @@ public:
 
 	// defs
 
-	typedef enum
+	typedef enum: char
 	{
-		TL_SPACE,
+		TL_SPACE = 0,
 		TL_1,
 		TL_2,
 		TL_3,

--- a/cpp/8puzzle.cpp
+++ b/cpp/8puzzle.cpp
@@ -7,6 +7,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include <iostream>
+#include <sstream>
 #include <stdio.h>
 #include <assert.h>
 #include <new>
@@ -115,6 +116,7 @@ public:
 	bool GetSuccessors( AStarSearch<PuzzleState> *astarsearch, PuzzleState *parent_node );
 	float GetCost( PuzzleState &successor );
 	bool IsSameState( PuzzleState &rhs );
+	size_t Hash();
 	
 	void PrintNodeInfo(); 
 
@@ -333,6 +335,19 @@ bool PuzzleState::IsSameState( PuzzleState &rhs )
 
 	return true;
 
+}
+
+// The 9 tiles positions can be encoded as digits
+size_t PuzzleState::Hash()
+{
+	stringstream stream;
+	for( size_t i = 0; i < (BOARD_HEIGHT * BOARD_WIDTH); i++ )
+	{
+		stream << tiles[i];
+	}
+	size_t state_digits;
+	stream >> state_digits;
+	return hash<size_t>{}(state_digits);
 }
 
 void PuzzleState::PrintNodeInfo()

--- a/cpp/findpath.cpp
+++ b/cpp/findpath.cpp
@@ -110,6 +110,8 @@ bool MapSearchNode::IsSameState( MapSearchNode &rhs )
 
 }
 
+// This hash is an example from https://en.cppreference.com/w/cpp/utility/hash
+// which works well for simple (X,Y) states
 size_t MapSearchNode::Hash()
 {
 	size_t h1 = hash<float>{}(x);

--- a/cpp/findpath.cpp
+++ b/cpp/findpath.cpp
@@ -87,6 +87,7 @@ public:
 	bool GetSuccessors( AStarSearch<MapSearchNode> *astarsearch, MapSearchNode *parent_node );
 	float GetCost( MapSearchNode &successor );
 	bool IsSameState( MapSearchNode &rhs );
+	size_t Hash();
 
 	void PrintNodeInfo(); 
 
@@ -107,6 +108,13 @@ bool MapSearchNode::IsSameState( MapSearchNode &rhs )
 		return false;
 	}
 
+}
+
+size_t MapSearchNode::Hash()
+{
+	size_t h1 = hash<float>{}(x);
+	size_t h2 = hash<float>{}(y);
+	return h1 ^ (h2 << 1);
 }
 
 void MapSearchNode::PrintNodeInfo()

--- a/cpp/min_path_to_Bucharest.cpp
+++ b/cpp/min_path_to_Bucharest.cpp
@@ -49,6 +49,7 @@ public:
 	bool GetSuccessors( AStarSearch<PathSearchNode> *astarsearch, PathSearchNode *parent_node );
 	float GetCost( PathSearchNode &successor );
 	bool IsSameState( PathSearchNode &rhs );
+  size_t Hash();
 
 	void PrintNodeInfo();
 };
@@ -58,6 +59,11 @@ bool PathSearchNode::IsSameState( PathSearchNode &rhs )
 {
   if(city == rhs.city) return(true);
   return(false);
+}
+
+size_t PathSearchNode::Hash()
+{
+  return hash<int>{}(city);
 }
 
 // Euclidean distance between "this" node city and Bucharest

--- a/cpp/min_path_to_Bucharest.cpp
+++ b/cpp/min_path_to_Bucharest.cpp
@@ -29,9 +29,9 @@ using namespace std;
 #define DEBUG_LISTS 0
 #define DEBUG_LIST_LENGTHS_ONLY 0
 
-const int MAX_CITIES = 20;
+const size_t MAX_CITIES = 20;
 
-enum ENUM_CITIES{Arad=0, Bucharest, Craiova, Drobeta, Eforie, Fagaras, Giurgiu, Hirsova, Iasi, Lugoj, Mehadia, Neamt, Oradea, Pitesti, RimnicuVilcea, Sibiu, Timisoara, Urziceni, Vaslui, Zerind};
+enum ENUM_CITIES: size_t {Arad=0, Bucharest, Craiova, Drobeta, Eforie, Fagaras, Giurgiu, Hirsova, Iasi, Lugoj, Mehadia, Neamt, Oradea, Pitesti, RimnicuVilcea, Sibiu, Timisoara, Urziceni, Vaslui, Zerind};
 vector<string> CityNames(MAX_CITIES);
 float RomaniaMap[MAX_CITIES][MAX_CITIES];
 
@@ -63,7 +63,7 @@ bool PathSearchNode::IsSameState( PathSearchNode &rhs )
 
 size_t PathSearchNode::Hash()
 {
-  return hash<int>{}(city);
+  return hash<size_t>{}(city);
 }
 
 // Euclidean distance between "this" node city and Bucharest
@@ -109,7 +109,7 @@ bool PathSearchNode::IsGoal( PathSearchNode &nodeGoal )
 bool PathSearchNode::GetSuccessors( AStarSearch<PathSearchNode> *astarsearch, PathSearchNode *parent_node )
 {
   PathSearchNode NewNode;
-  for(int c=0; c<MAX_CITIES; c++)
+  for(size_t c=0; c<MAX_CITIES; c++)
   {
     if(RomaniaMap[city][c] < 0) continue;
     NewNode = PathSearchNode((ENUM_CITIES)c);
@@ -133,8 +133,8 @@ void PathSearchNode::PrintNodeInfo()
 int main( int argc, char *argv[] )
 {
   // creating map of Romania
-  for(int i=0; i<MAX_CITIES; i++)
-    for(int j=0; j<MAX_CITIES; j++)
+  for(size_t i=0; i<MAX_CITIES; i++)
+    for(size_t j=0; j<MAX_CITIES; j++)
       RomaniaMap[i][j]=-1.0;
 
   RomaniaMap[Arad][Sibiu]=140;

--- a/cpp/stlastar.h
+++ b/cpp/stlastar.h
@@ -34,6 +34,8 @@ given where due.
 // stl includes
 #include <algorithm>
 #include <set>
+#include <unordered_set>
+// #include <boost/functional/hash.hpp>
 #include <vector>
 #include <cfloat>
 
@@ -94,8 +96,24 @@ public: // data
 			{			
 			}
 
+			bool operator==(const Node& otherNode) const
+			{
+				return this->m_UserState.IsSameState(otherNode->m_UserState);
+			}
+
 			UserState m_UserState;
 	};
+
+	// template<>
+	// struct std::hash<Node>
+	// {
+	// 		std::size_t operator()(Node const& n) const noexcept
+	// 		{
+	// 				std::size_t h1 = std::hash<std::string>{}(n.g);
+	// 				std::size_t h2 = std::hash<std::string>{}(n.h);
+	// 				return h1 ^ (h2 << 1); // or use boost::hash_combine
+	// 		}
+	// };
 
 
 	// For sorting the heap the STL needs compare function that lets us compare
@@ -283,9 +301,9 @@ public: // methods
 			}
 			
 			// Now handle each successor to the current node ...
-			for( typename vector< Node * >::iterator successor = m_Successors.begin(); successor != m_Successors.end(); successor ++ )
+			for( typename vector< Node * >::iterator s = m_Successors.begin(); s != m_Successors.end(); s ++ )
 			{
-
+				auto successor = &(*s);
 				// 	The g value for this successor ...
 				float newg = n->g + n->m_UserState.GetCost( (*successor)->m_UserState );
 
@@ -319,15 +337,17 @@ public: // methods
 					}
 				}
 
-				typename vector< Node * >::iterator closedlist_result;
+				// typename vector< Node * >::iterator closedlist_result;
 
-				for( closedlist_result = m_ClosedList.begin(); closedlist_result != m_ClosedList.end(); closedlist_result ++ )
-				{
-					if( (*closedlist_result)->m_UserState.IsSameState( (*successor)->m_UserState ) )
-					{
-						break;					
-					}
-				}
+				// for( closedlist_result = m_ClosedList.begin(); closedlist_result != m_ClosedList.end(); closedlist_result ++ )
+				// {
+				// 	if( (*closedlist_result)->m_UserState.IsSameState( (*successor)->m_UserState ) )
+				// 	{
+				// 		break;					
+				// 	}
+				// }
+
+				auto closedlist_result = m_ClosedList.find(*successor);
 
 				if( closedlist_result != m_ClosedList.end() )
 				{
@@ -424,7 +444,7 @@ public: // methods
 
 			// push n onto Closed, as we have expanded it now
 
-			m_ClosedList.push_back( n );
+			m_ClosedList.insert( n );
 
 		} // end else (not goal so expand)
 
@@ -681,7 +701,7 @@ private: // methods
 		m_OpenList.clear();
 
 		// iterate closed list and delete unused nodes
-		typename vector< Node * >::iterator iterClosed;
+		typename unordered_set< Node * >::iterator iterClosed;
 
 		for( iterClosed = m_ClosedList.begin(); iterClosed != m_ClosedList.end(); iterClosed ++ )
 		{
@@ -722,7 +742,7 @@ private: // methods
 		m_OpenList.clear();
 
 		// iterate closed list and delete unused nodes
-		typename vector< Node * >::iterator iterClosed;
+		typename unordered_set< Node * >::iterator iterClosed;
 
 		for( iterClosed = m_ClosedList.begin(); iterClosed != m_ClosedList.end(); iterClosed ++ )
 		{
@@ -780,7 +800,24 @@ private: // data
 	vector< Node *> m_OpenList;
 
 	// Closed list is a vector.
-	vector< Node * > m_ClosedList; 
+// 	struct NodePtrComp
+// {
+//   bool operator()(const Node* lhs, const Node* rhs) const  { return lhs->f < rhs->f;} //#TODO: read the is same state/use unordered_set which has a better condition
+// };
+// 	set< Node*, NodePtrComp > m_ClosedList; 
+	// struct NodeHash {
+	// size_t operator() (Node* const& n) const {
+	// 		// std::size_t seed = 0;
+	// 		// boost::hash_combine(seed, n->g);
+	// 		// boost::hash_combine(seed, n->h);
+	// 		// return seed;
+	// 		std::size_t h1 = 0;//std::hash<float>{}(n->m_UserState.g);
+	// 		std::size_t h2 = 1;//std::hash<float>{}(n->m_UserState.h);
+	// 		return h1 ^ (h2 << 1); // or use boost::hash_combine
+	// };
+	// unordered_set<Node*, NodeHash> m_ClosedList;
+		unordered_set<Node*> m_ClosedList;
+
 
 	// Successors is a vector filled out by the user each type successors to a node
 	// are generated

--- a/cpp/stlastar.h
+++ b/cpp/stlastar.h
@@ -33,9 +33,7 @@ given where due.
 
 // stl includes
 #include <algorithm>
-#include <set>
 #include <unordered_set>
-// #include <boost/functional/hash.hpp>
 #include <vector>
 #include <cfloat>
 
@@ -777,7 +775,7 @@ private: // data
 	// Heap (simple vector but used as a heap, cf. Steve Rabin's game gems article)
 	vector< Node *> m_OpenList;
 
-	// Closed list is a set
+	// Closed is an unordered_set
 	struct NodeHash {
 		size_t operator() (Node* const& n) const {
 			return n->m_UserState.Hash();
@@ -833,7 +831,7 @@ public:
 	virtual bool GetSuccessors( AStarSearch<T> *astarsearch, T *parent_node ) = 0; // Retrieves all successors to this node and adds them via astarsearch.addSuccessor()
 	virtual float GetCost( T &successor ) = 0; // Computes the cost of travelling from this node to the successor node
 	virtual bool IsSameState( T &rhs ) = 0; // Returns true if this node is the same as the rhs node
-	virtual float Hash() = 0;
+	virtual std::size_t Hash() = 0; // Returns a hash for the state
 };
 
 #endif

--- a/cpp/stlastar.h
+++ b/cpp/stlastar.h
@@ -287,9 +287,8 @@ public: // methods
 			}
 			
 			// Now handle each successor to the current node ...
-			for( typename vector< Node * >::iterator s = m_Successors.begin(); s != m_Successors.end(); s ++ )
+			for( typename vector< Node * >::iterator successor = m_Successors.begin(); successor != m_Successors.end(); successor ++ )
 			{
-				auto successor = &(*s);
 				// 	The g value for this successor ...
 				float newg = n->g + n->m_UserState.GetCost( (*successor)->m_UserState );
 

--- a/cpp/stlastar.h
+++ b/cpp/stlastar.h
@@ -104,18 +104,6 @@ public: // data
 			UserState m_UserState;
 	};
 
-	// template<>
-	// struct std::hash<Node>
-	// {
-	// 		std::size_t operator()(Node const& n) const noexcept
-	// 		{
-	// 				std::size_t h1 = std::hash<std::string>{}(n.g);
-	// 				std::size_t h2 = std::hash<std::string>{}(n.h);
-	// 				return h1 ^ (h2 << 1); // or use boost::hash_combine
-	// 		}
-	// };
-
-
 	// For sorting the heap the STL needs compare function that lets us compare
 	// the f value of two nodes
 
@@ -336,16 +324,6 @@ public: // methods
 						continue;
 					}
 				}
-
-				// typename vector< Node * >::iterator closedlist_result;
-
-				// for( closedlist_result = m_ClosedList.begin(); closedlist_result != m_ClosedList.end(); closedlist_result ++ )
-				// {
-				// 	if( (*closedlist_result)->m_UserState.IsSameState( (*successor)->m_UserState ) )
-				// 	{
-				// 		break;					
-				// 	}
-				// }
 
 				auto closedlist_result = m_ClosedList.find(*successor);
 
@@ -701,7 +679,7 @@ private: // methods
 		m_OpenList.clear();
 
 		// iterate closed list and delete unused nodes
-		typename unordered_set< Node * >::iterator iterClosed;
+		typename unordered_set<Node*, NodeHash, NodeEqual>::iterator iterClosed;
 
 		for( iterClosed = m_ClosedList.begin(); iterClosed != m_ClosedList.end(); iterClosed ++ )
 		{
@@ -742,7 +720,7 @@ private: // methods
 		m_OpenList.clear();
 
 		// iterate closed list and delete unused nodes
-		typename unordered_set< Node * >::iterator iterClosed;
+		typename unordered_set<Node*, NodeHash, NodeEqual>::iterator iterClosed;
 
 		for( iterClosed = m_ClosedList.begin(); iterClosed != m_ClosedList.end(); iterClosed ++ )
 		{
@@ -799,24 +777,18 @@ private: // data
 	// Heap (simple vector but used as a heap, cf. Steve Rabin's game gems article)
 	vector< Node *> m_OpenList;
 
-	// Closed list is a vector.
-// 	struct NodePtrComp
-// {
-//   bool operator()(const Node* lhs, const Node* rhs) const  { return lhs->f < rhs->f;} //#TODO: read the is same state/use unordered_set which has a better condition
-// };
-// 	set< Node*, NodePtrComp > m_ClosedList; 
-	// struct NodeHash {
-	// size_t operator() (Node* const& n) const {
-	// 		// std::size_t seed = 0;
-	// 		// boost::hash_combine(seed, n->g);
-	// 		// boost::hash_combine(seed, n->h);
-	// 		// return seed;
-	// 		std::size_t h1 = 0;//std::hash<float>{}(n->m_UserState.g);
-	// 		std::size_t h2 = 1;//std::hash<float>{}(n->m_UserState.h);
-	// 		return h1 ^ (h2 << 1); // or use boost::hash_combine
-	// };
-	// unordered_set<Node*, NodeHash> m_ClosedList;
-		unordered_set<Node*> m_ClosedList;
+	// Closed list is a set
+	struct NodeHash {
+		size_t operator() (Node* const& n) const {
+			return n->m_UserState.Hash();
+		}
+	};
+	struct NodeEqual {
+		bool operator()(Node* a, Node* b) const {
+			return a->m_UserState.IsSameState(b->m_UserState);
+  	}
+	};
+	unordered_set<Node*, NodeHash, NodeEqual> m_ClosedList;
 
 
 	// Successors is a vector filled out by the user each type successors to a node
@@ -861,6 +833,7 @@ public:
 	virtual bool GetSuccessors( AStarSearch<T> *astarsearch, T *parent_node ) = 0; // Retrieves all successors to this node and adds them via astarsearch.addSuccessor()
 	virtual float GetCost( T &successor ) = 0; // Computes the cost of travelling from this node to the successor node
 	virtual bool IsSameState( T &rhs ) = 0; // Returns true if this node is the same as the rhs node
+	virtual float Hash() = 0;
 };
 
 #endif

--- a/cpp/stlastar.h
+++ b/cpp/stlastar.h
@@ -831,7 +831,7 @@ public:
 	virtual bool GetSuccessors( AStarSearch<T> *astarsearch, T *parent_node ) = 0; // Retrieves all successors to this node and adds them via astarsearch.addSuccessor()
 	virtual float GetCost( T &successor ) = 0; // Computes the cost of travelling from this node to the successor node
 	virtual bool IsSameState( T &rhs ) = 0; // Returns true if this node is the same as the rhs node
-	virtual std::size_t Hash() = 0; // Returns a hash for the state
+	virtual size_t Hash() = 0; // Returns a hash for the state
 };
 
 #endif

--- a/cpp/tests.cpp
+++ b/cpp/tests.cpp
@@ -73,6 +73,7 @@ public:
 	bool GetSuccessors( AStarSearch<MapSearchNode> *astarsearch, MapSearchNode *parent_node );
 	float GetCost( MapSearchNode &successor );
 	bool IsSameState( MapSearchNode &rhs );
+	size_t Hash();
 
 	void PrintNodeInfo(); 
 
@@ -188,6 +189,13 @@ float MapSearchNode::GetCost( MapSearchNode &successor )
 {
 	return (float) GetMap( x, y );
 
+}
+
+size_t MapSearchNode::Hash()
+{
+	size_t h1 = hash<float>{}(x);
+	size_t h2 = hash<float>{}(y);
+	return h1 ^ (h2 << 1);
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
The A* library uses a closed list which is slow to look up if a state has been visited. I've changed to a hash set via the unordered_set which speeds up search.
In my use case, this took the mean search time from 0.0141 seconds to 0.0016 seconds and the max search time from ~2.8 seconds to ~0.34 seconds.

I updated the examples to also use the hash. If there is a better way to handle the hash function let me know. I had trouble using the hash template specialization with the other templating in the library, and this way became easier.