### PR TITLE
Update AStarExample.cs

### DIFF
--- a/cs/AStarExample.cs
+++ b/cs/AStarExample.cs
@@ -132,7 +132,7 @@ public class MapSearchNode
 	// is specific to the application
 	public bool GetSuccessors(AStarPathfinder aStarSearch, MapSearchNode parentNode)
 	{
-		NodePosition parentPos = new NodePosition(0, 0);
+		NodePosition parentPos = new NodePosition(-1, -1);
 
 		if (parentNode != null)
 		{


### PR DESCRIPTION
Corrected initialization of parentPos in GetSuccessors() method of MapSearchNode to (-1, -1).